### PR TITLE
Unhardcode icon path in GNU/Linux laucher

### DIFF
--- a/ZeGrapher.desktop
+++ b/ZeGrapher.desktop
@@ -6,6 +6,6 @@ Comment[fr]=Logiciel de tacé de courbes
 Exec=/usr/bin/ZeGrapher
 Terminal=false
 Type=Application
-Icon=/usr/share/pixmaps/ZeGrapher.ico
+Icon=ZeGrapher
 MimeType=x-scheme-handler/ZeGrapher;
 Categories=Office;


### PR DESCRIPTION
Since the icon already is installed to a location compliant with [freedesktop.org standards](https://specifications.freedesktop.org/icon-theme-spec/icon-theme-spec-latest.html) you don't need to specify the full icon path (neither the file type extension) in the launcher. The icon will be found anyway.

This facilitates icon theming.
Cf. this [example ``.desktop`` launcher](https://specifications.freedesktop.org/desktop-entry-spec/desktop-entry-spec-latest.html#example) presented in the freedesktop.org documentation.