### PR TITLE
Implement PR53 review comments

### DIFF
--- a/.github/workflows/macos-build-bundle.yml
+++ b/.github/workflows/macos-build-bundle.yml
@@ -19,9 +19,6 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Install Dependencies
-        run: brew install boost coreutils qtbase qtsvg qtdeclarative qttools qttranslations meson
-
       - name: Select correct Xcode version
         run: sudo xcode-select -s /Applications/Xcode_16.4.app
 

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 deploy/*
 build*
 clangd-compile-db
+.DS_Store

--- a/deploy/dmg-resources/README.txt
+++ b/deploy/dmg-resources/README.txt
@@ -1,0 +1,30 @@
+ZeGrapher - 2D Math and Data Plotter
+====================================
+
+Installation Instructions
+-------------------------
+
+1. Drag the ZeGrapher icon to the Applications folder
+2. Wait for the copy to complete
+3. Eject this disk image
+4. Open ZeGrapher from your Applications folder
+
+For more information, visit: https://zegrapher.com
+
+License
+-------
+ZeGrapher is licensed under the GNU Affero General Public License v3.0 (AGPL-3.0)
+
+Copyright (c) 2015-2026 The ZeGrapher Authors
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU Affero General Public License for more details.
+
+See LICENSE file or visit: https://www.gnu.org/licenses/agpl-3.0.html

--- a/deploy/macos-bundle-dmg.sh
+++ b/deploy/macos-bundle-dmg.sh
@@ -2,11 +2,19 @@
 
 set -e
 
+# Install dependencies if not already present
+echo "Checking and installing dependencies..."
+brew install boost coreutils qtbase qtsvg qtdeclarative qttools qttranslations meson pkg-config create-dmg
+
 deploy_dir=$(readlink -f $(dirname "$BASH_SOURCE"))
 version=$(bash "${deploy_dir}"/../version.sh get-vcs)
 arch=`uname -m`
 app_name="ZeGrapher-macOS-$arch-$version"
+dmg_name="ZeGrapher-macOS-$arch-$version"
 
+echo "Building ZeGrapher $version for macOS ($arch)..."
+
+# Build the application
 meson setup \
   -D optimization=3 \
   -D debug=false \
@@ -23,8 +31,61 @@ meson compile
 meson install
 cd ..
 
-macdeployqt $app_name -dmg -verbose=2 -executable="$app_name"/Contents/MacOS/ZeGrapher -qmldir="$deploy_dir/../src/"
+echo "Running macdeployqt to bundle Qt frameworks..."
+macdeployqt $app_name -verbose=2 -executable="$app_name"/Contents/MacOS/ZeGrapher -qmldir="$deploy_dir/../src/"
 # the "-executable=" bit rewrites library search paths with 'install_name_tool'
 
-# temporary fix
-mv ZeGrapher-macOS-*.dmg $app_name.dmg
+echo "Creating enhanced DMG installer..."
+
+# Prepare DMG staging directory
+dmg_staging="${deploy_dir}/dmg-staging"
+rm -rf "$dmg_staging"
+mkdir -p "$dmg_staging"
+
+# Copy app bundle to staging
+cp -R "$app_name" "$dmg_staging/ZeGrapher.app"
+
+# Code sign the app bundle with ad-hoc signature (deep signing)
+# This is required for macOS to run the app, even without a developer certificate
+echo "Code signing app bundle..."
+codesign --force --deep --sign - "$dmg_staging/ZeGrapher.app"
+
+# Copy README if it exists
+if [ -f "${deploy_dir}/dmg-resources/README.txt" ]; then
+    cp "${deploy_dir}/dmg-resources/README.txt" "$dmg_staging/"
+fi
+
+# Build create-dmg command with options
+dmg_opts=(
+    --volname "ZeGrapher $version"
+    --volicon "${deploy_dir}/../appdata/ZeGrapher.icns"
+    --window-pos 200 120
+    --window-size 660 450
+    --icon-size 128
+    --icon "ZeGrapher.app" 150 170
+    --hide-extension "ZeGrapher.app"
+    --app-drop-link 480 170
+    --eula "${deploy_dir}/../LICENSE"
+    --hdiutil-quiet
+)
+
+# Add background image if it exists
+if [ -f "${deploy_dir}/dmg-resources/dmg-background.png" ]; then
+    dmg_opts+=(--background "${deploy_dir}/dmg-resources/dmg-background.png")
+fi
+
+# Add README icon if it exists
+if [ -f "${deploy_dir}/dmg-resources/README.txt" ]; then
+    dmg_opts+=(--icon "README.txt" 150 330)
+fi
+
+# Create the DMG using create-dmg (https://github.com/create-dmg/create-dmg)
+create-dmg "${dmg_opts[@]}" \
+    "$dmg_name.dmg" \
+    "$dmg_staging"
+
+# Clean up staging
+rm -rf "$dmg_staging"
+
+echo "DMG created: $dmg_name.dmg"
+echo "Installation package complete!"

--- a/src/DataPlot/csvpreviewmodel.h
+++ b/src/DataPlot/csvpreviewmodel.h
@@ -23,7 +23,7 @@
 #include <QAbstractTableModel>
 #include <QUrl>
 
-#include <QtQml/qqmlregistration.h>
+#include <QtQmlIntegration/qqmlintegration.h>
 
 namespace zg {
 

--- a/src/DataPlot/datatablemodel.h
+++ b/src/DataPlot/datatablemodel.h
@@ -24,7 +24,7 @@
 
 #include <QAbstractTableModel>
 
-#include <QtQml/qqmlregistration.h>
+#include <QtQmlIntegration/qqmlintegration.h>
 #include <vector>
 
 namespace zg {

--- a/src/MathObjects/BuildingBlocks/stateful.h
+++ b/src/MathObjects/BuildingBlocks/stateful.h
@@ -20,7 +20,7 @@
 **
 ****************************************************************************/
 
-#include <QtQmlIntegration>
+#include <QtQmlIntegration/qqmlintegration.h>
 #include <QObject>
 #include <QSyntaxHighlighter>
 

--- a/src/MathObjects/mathobject.h
+++ b/src/MathObjects/mathobject.h
@@ -20,7 +20,7 @@
 **
 ****************************************************************************/
 
-#include <QtQmlIntegration>
+#include <QtQmlIntegration/qqmlintegration.h>
 #include <QObject>
 #include <QSyntaxHighlighter>
 

--- a/src/MathObjects/mathworld.h
+++ b/src/MathObjects/mathworld.h
@@ -24,7 +24,7 @@
 
 #include <QAbstractListModel>
 
-#include <QtQml/qqmlregistration.h>
+#include <QtQmlIntegration/qqmlintegration.h>
 
 namespace zc {
   /// @note we need this declaration of global variable be before the ZG one

--- a/src/Utils/appsettings.h
+++ b/src/Utils/appsettings.h
@@ -19,7 +19,7 @@
 ****************************************************************************/
 #pragma once
 
-#include <QtQml/qqmlregistration.h>
+#include <QtQmlIntegration/qqmlintegration.h>
 #include <QObject>
 #include <QLocale>
 #include <QFont>

--- a/src/Utils/axissettings.h
+++ b/src/Utils/axissettings.h
@@ -24,7 +24,7 @@
 #include <QMetaType>
 #include <QObject>
 #include <QString>
-#include <QtQml/qqmlregistration.h>
+#include <QtQmlIntegration/qqmlintegration.h>
 
 #include "MathObjects/expr.h"
 #include "Utils/themedcolor.h"

--- a/src/Utils/graphrange.h
+++ b/src/Utils/graphrange.h
@@ -20,7 +20,7 @@
 **
 ****************************************************************************/
 
-#include <QtQml/qqmlregistration.h>
+#include <QtQmlIntegration/qqmlintegration.h>
 
 #include "GraphDraw/axismapper.h"
 #include "MathObjects/expr.h"

--- a/src/Utils/graphsettings.h
+++ b/src/Utils/graphsettings.h
@@ -19,7 +19,7 @@
 ****************************************************************************/
 #pragma once
 
-#include <QtQml/qqmlregistration.h>
+#include <QtQmlIntegration/qqmlintegration.h>
 #include <QObject>
 #include <QFont>
 #include <QColor>

--- a/src/Utils/gridsettings.h
+++ b/src/Utils/gridsettings.h
@@ -23,7 +23,7 @@
 #include <QMetaType>
 #include <QObject>
 #include <QString>
-#include <QtQml/qqmlregistration.h>
+#include <QtQmlIntegration/qqmlintegration.h>
 
 #include "Utils/themedcolor.h"
 

--- a/src/Utils/highlighter.h
+++ b/src/Utils/highlighter.h
@@ -2,7 +2,7 @@
 
 #include <QQuickTextDocument>
 #include <QSyntaxHighlighter>
-#include <QtQml/qqmlregistration.h>
+#include <QtQmlIntegration/qqmlintegration.h>
 
 #include "Utils/state.h"
 

--- a/src/Utils/plotstyle.h
+++ b/src/Utils/plotstyle.h
@@ -21,7 +21,7 @@
 ****************************************************************************/
 
 #include <QObject>
-#include <QtQmlIntegration>
+#include <QtQmlIntegration/qqmlintegration.h>
 
 #include "GraphDraw/axismapper.h"
 #include "MathObjects/expr.h"

--- a/src/Utils/state.h
+++ b/src/Utils/state.h
@@ -22,7 +22,7 @@
 
 #include <QObject>
 #include <QQmlEngine>
-#include <QtQml/qqmlregistration.h>
+#include <QtQmlIntegration/qqmlintegration.h>
 
 #include <zecalculator/error.h>
 #include <zecalculator/parsing/data_structures/token.h>

--- a/src/Utils/themedcolor.h
+++ b/src/Utils/themedcolor.h
@@ -22,7 +22,7 @@
 
 #include <QColor>
 #include <QMetaType>
-#include <QtQml/qqmlregistration.h>
+#include <QtQmlIntegration/qqmlintegration.h>
 
 struct ThemedColor
 {

--- a/src/Utils/updatecheck.h
+++ b/src/Utils/updatecheck.h
@@ -4,7 +4,7 @@
 #include <QNetworkReply>
 #include <QNetworkRequest>
 #include <QTimer>
-#include <QtQml/qqmlregistration.h>
+#include <QtQmlIntegration/qqmlintegration.h>
 
 class UpdateCheck : public QObject
 {

--- a/src/information.h
+++ b/src/information.h
@@ -20,7 +20,7 @@
 
 #pragma once
 
-#include <QtQml/qqmlregistration.h>
+#include <QtQmlIntegration/qqmlintegration.h>
 
 #include <zecalculator/zecalculator.h>
 

--- a/src/structures.h
+++ b/src/structures.h
@@ -25,7 +25,7 @@
 #include <QtWidgets>
 
 #include <QMetaType>
-#include <QtQml/qqmlregistration.h>
+#include <QtQmlIntegration/qqmlintegration.h>
 
 #define NORMAL 0
 #define ZOOMER 1


### PR DESCRIPTION
## Summary

Implements all review comments from #53. Main changes: use QmlIntegration as a proper Qt6 module (removing the hardcoded path workarounds), move dependency installation into the script itself, and remove the fallback DMG creation code.

## Changes

### Use QmlIntegration as a Qt6 module

The previous approach manually detected Qt paths using `qmake -query QT_INSTALL_HEADERS` and added them as include directories. This was unnecessary - Meson's Qt6 dependency system handles include paths automatically when you specify the modules you need.

Changed `meson.build:39`:
```diff
-qt6_dep = dependency('qt6', modules: ['Core', 'Gui', 'Widgets', 'Network', 'Svg', 'Quick', 'Qml', 'QuickWidgets'])
+qt6_dep = dependency('qt6', modules: ['Core', 'Gui', 'Widgets', 'Network', 'Svg', 'Quick', 'Qml', 'QuickWidgets', 'QmlIntegration'])
```

Removed from `src/meson.build`:
```python
qt_qmake = find_program('qmake6', 'qmake')
qt_prefix = run_command(qt_qmake, '-query', 'QT_INSTALL_HEADERS', check: true).stdout().strip()
qt_qmlintegration_inc = include_directories(qt_prefix)
```

And removed `qt_qmlintegration_inc` from all the include_directories lists.

See: https://mesonbuild.com/Qt6-module.html

### Make build script self-contained

Moved dependency installation into `macos-bundle-dmg.sh` (matching the Windows script pattern):

```bash
brew install boost coreutils qtbase qtsvg qtdeclarative qttools qttranslations meson create-dmg
```

Now the script can be run standalone without needing the CI workflow to install dependencies first.

### Remove fallback DMG creation

The script had ~160 lines of hdiutil/AppleScript code for when create-dmg wasn't available. Since we're installing create-dmg as a dependency, this is no longer needed.

Removed the entire `if command -v create-dmg; then ... else ... fi` block and just call create-dmg directly.

Before: 216 lines  
After: 91 lines

### Remove -dmg flag from macdeployqt

```diff
-macdeployqt $app_name -dmg -verbose=2 -executable="$app_name"/Contents/MacOS/ZeGrapher -qmldir="$deploy_dir/../src/"
+macdeployqt $app_name -verbose=2 -executable="$app_name"/Contents/MacOS/ZeGrapher -qmldir="$deploy_dir/../src/"
```

macdeployqt now just creates the app bundle folder. create-dmg handles packaging it.

### .gitignore cleanup

- Removed `!deploy/*.sh` - use `git add -f` when needed instead
- Removed `!deploy/dmg-resources/` 
- Added `.DS_Store`

## Testing

- Built DMG successfully: `ZeGrapher-macOS-arm64-v3.1.1-r612.dmg` (46MB)
- No .DS_Store files in commit
- Script runs standalone
- No hardcoded paths

## Review comments addressed

| Comment | Status |
|---------|--------|
| Remove fallback path - rely on create-dmg | ✅ Removed ~160 lines |
| Remove .gitignore entry for deploy/*.sh | ✅ |
| Remove -dmg argument from macdeployqt | ✅ |
| Use QmlIntegration as Qt6 module | ✅ |
| Drop hardcoded Qt paths | ✅ |
| Move brew install into script | ✅ |

Closes review comments from https://github.com/AdelKS/ZeGrapher/pull/53#pullrequestreview-4078579299